### PR TITLE
Features added v1006

### DIFF
--- a/BField_LSQ_package/mu2e/cfg_defs.py
+++ b/BField_LSQ_package/mu2e/cfg_defs.py
@@ -7,5 +7,5 @@ cfg_plot   = namedtuple('cfg_plot', 'plot_type zlims save_loc sub_dir df_fine')
 cfg_params = namedtuple('cfg_params', 'pitch1 ms_h1 ns_h1 pitch2 ms_h2 ns_h2 '
                         ' length1 ms_c1 ns_c1 length2 ms_c2 ns_c2 '
                         ' ks_dict bs_tuples bs_bounds loss version '
-                        ' method ms_asym_max cfg_calc_data noise', defaults=('leastsq', -1, None, None))
+                        ' method ms_asym_max cfg_calc_data noise z0', defaults=('leastsq', -1, None, None, None))
 cfg_pickle = namedtuple('cfg_pickle', 'use_pickle save_pickle load_name save_name recreate')

--- a/BField_LSQ_package/mu2e/cfg_defs.py
+++ b/BField_LSQ_package/mu2e/cfg_defs.py
@@ -7,5 +7,5 @@ cfg_plot   = namedtuple('cfg_plot', 'plot_type zlims save_loc sub_dir df_fine')
 cfg_params = namedtuple('cfg_params', 'pitch1 ms_h1 ns_h1 pitch2 ms_h2 ns_h2 '
                         ' length1 ms_c1 ns_c1 length2 ms_c2 ns_c2 '
                         ' ks_dict bs_tuples bs_bounds loss version '
-                        ' method ms_asym_max cfg_calc_data noise z0', defaults=('leastsq', -1, None, None, None))
+                        ' method ms_asym_max cfg_calc_data noise z0 AB_lim k_lim', defaults=('leastsq', -1, None, None, None, None, None))
 cfg_pickle = namedtuple('cfg_pickle', 'use_pickle save_pickle load_name save_name recreate')

--- a/BField_LSQ_package/mu2e/fieldfitter_redux2.py
+++ b/BField_LSQ_package/mu2e/fieldfitter_redux2.py
@@ -284,13 +284,13 @@ class FieldFitter:
             self.add_params_cyl(2)
             self.add_params_cart_simple(cfg_params)
             self.add_params_biot_savart(cfg_params, cfg_pickle.recreate)
-        # z0 offset
+        # z0 offset, introduction of new k scheme (can control whether each is varied)
         elif func_version == 1006:
             self.add_params_hel(1)
             self.add_params_hel(2)
-            self.add_params_cyl_v1005(1)
+            self.add_params_cyl_v1006(1, AB_lim=cfg_params.AB_lim)
             self.add_params_cyl(2)
-            self.add_params_cart_simple(cfg_params)
+            self.add_params_cart_simple_fixable(cfg_params)
             self.add_params_biot_savart(cfg_params, cfg_pickle.recreate)
             #z0
             if not cfg_params.z0 is None:
@@ -360,6 +360,7 @@ class FieldFitter:
                 self.result = self.mod.fit(np.concatenate([self.Br, self.Bz, self.Bphi]).ravel(),
                                            weights=weights, scale_covar=False,
                                            r=self.RR, z=self.ZZ, phi=self.PP, x=self.XX, y=self.YY, params=self.params,
+                                           iter_cb=print_status,
                                            method=cfg_params.method) #max_nfev if wanting to limit function calls
             elif cfg_params.method == 'least_squares':
                 self.result = self.mod.fit(np.concatenate([self.Br, self.Bz, self.Bphi]).ravel(),
@@ -517,6 +518,8 @@ class FieldFitter:
         # max asymmetric terms
         if 'ms_asym_max' not in self.params:
             self.params.add('ms_asym_max', value=cfg_params.ms_asym_max, vary=False)
+        else:
+            self.params['ms_asym_max'].value = cfg_params.ms_asym_max
 
     def add_params_hel(self, num):
         ms_range = range(self.params[f'ms_h{num}'].value)
@@ -564,6 +567,48 @@ class FieldFitter:
                         self.params.add(f'Dh{num}_{m}_{n}', value=0, vary=False)
                     else:
                         self.params[f'Dh{num}_{m}_{n}'].vary = False
+
+    def add_params_cyl_v1006(self, num, AB_lim=None):
+        ms_range = range(self.params[f'ms_c{num}'].value)
+        ns_range = range(self.params[f'ns_c{num}'].value)
+        #np.random.seed(0)
+        m_max = self.params['ms_asym_max'].value
+        if m_max < 0:
+            m_max = np.inf
+
+        # limits on A/B?
+        if AB_lim is None:
+            AB_min = None
+            AB_max = None
+        else:
+            AB_min = -AB_lim
+            AB_max = AB_lim
+
+        for m in ms_range:
+            for n in ns_range:
+                if (m > m_max) & (n > 0):
+                    var = False
+                else:
+                    var = True
+                # A and B are linear
+                if f'Ac{num}_{m}_{n}' not in self.params:
+                    self.params.add(f'Ac{num}_{m}_{n}', value=0.0, vary=var, min=AB_min, max=AB_max)
+                else:
+                    self.params[f'Ac{num}_{m}_{n}'].vary = var
+                if f'Bc{num}_{m}_{n}' not in self.params:
+                    self.params.add(f'Bc{num}_{m}_{n}', value=0.0, vary=var, min=AB_min, max=AB_max)
+                else:
+                    self.params[f'Bc{num}_{m}_{n}'].vary = var
+                # D is the phi phase
+                if f'Dc{num}_{n}' not in self.params:
+                    if n > 0:
+                        self.params.add(f'Dc{num}_{n}', value=np.pi/4., min=0, max=np.pi, vary=True)
+                    # n=0 is constant term, no phase
+                    else:
+                        self.params.add(f'Dc{num}_{n}', value=np.pi/2, vary=False)
+                elif n > 0:
+                    self.params[f'Dc{num}_{n}'].min = 0.0
+                    self.params[f'Dc{num}_{n}'].max = np.pi
 
     def add_params_cyl_v1005(self, num):
         ms_range = range(self.params[f'ms_c{num}'].value)
@@ -887,6 +932,42 @@ class FieldFitter:
                 self.params.add(k, value=0, vary=False)
             elif k == 'k3':
                 self.params[k].min=0.0
+
+    def add_params_cart_simple_fixable(self, cfg_params):
+        ks_dict = cfg_params.ks_dict
+        if ks_dict is None:
+            ks_dict = {}
+        cart_names = [f'k{i}' for i in range(1, 11)]
+
+        # limits for k
+        k_lim = cfg_params.k_lim
+        if k_lim is None:
+            k_min = None
+            k_max = None
+        else:
+            k_min = -k_lim
+            k_max = k_lim
+
+        for k in cart_names:
+            if k not in self.params and k in ks_dict:
+                self.params.add(k, value=ks_dict[k][0], vary=ks_dict[k][1], min=k_min, max=k_max)
+                # if k == 'k3':
+                #     # Get initial value for k3 from Fourier transform of r=0 line
+                #     # with open('../data/fit_params/params_fourier.pkl','rb') as infile:
+                #     #     params_fourier = pkl.load(infile)
+                #     # self.params.add(k, value=params_fourier['k3'], vary=True)#True
+                #     # self.params.add(k, value=ks_dict[k], vary=True)
+                #     self.params.add(k, value=ks_dict[k], min=0.0, vary=True)
+                #     #self.params.add(k, value=13000, vary=True, min=13000, max=14000, brute_step=100)
+                #     #with open('../data/fit_params/DS_only_V1_results.p','rb') as infile:
+                #     #    params_V1 = pkl.load(infile)
+                #     #self.params.add(k, value=params_V1['k3'].value, vary=True)#True
+                # else:
+                #     self.params.add(k, value=ks_dict[k], vary=True)
+            elif k not in self.params:
+                self.params.add(k, value=0, vary=False)
+            #elif k == 'k3':
+            #    self.params[k].min=0.0
 
     def add_params_finite_wire(self):
         if 'k1' not in self.params:

--- a/BField_LSQ_package/mu2e/fieldfitter_redux2.py
+++ b/BField_LSQ_package/mu2e/fieldfitter_redux2.py
@@ -350,7 +350,7 @@ class FieldFitter:
             for param in self.params:
                 self.params[param].vary = False
             self.result = self.mod.fit(np.concatenate([self.Br, self.Bz, self.Bphi]).ravel(),
-                                       weights=weights,
+                                       weights=weights, scale_covar=False,
                                        r=self.RR, z=self.ZZ, phi=self.PP, x=self.XX, y=self.YY, params=self.params,
                                        method='leastsq', fit_kws={'maxfev': 1})
         else:
@@ -358,12 +358,12 @@ class FieldFitter:
             # mag = 1/np.sqrt(Br**2+Bz**2+Bphi**2)
             if cfg_params.method == 'leastsq' or cfg_params.method == 'brute':
                 self.result = self.mod.fit(np.concatenate([self.Br, self.Bz, self.Bphi]).ravel(),
-                                           weights=np.concatenate([noise_err, noise_err, noise_err]).ravel(),
+                                           weights=weights, scale_covar=False,
                                            r=self.RR, z=self.ZZ, phi=self.PP, x=self.XX, y=self.YY, params=self.params,
                                            method=cfg_params.method) #max_nfev if wanting to limit function calls
             elif cfg_params.method == 'least_squares':
                 self.result = self.mod.fit(np.concatenate([self.Br, self.Bz, self.Bphi]).ravel(),
-                                           weights=weights,
+                                           weights=weights, scale_covar=False,
                                            r=self.RR, z=self.ZZ, phi=self.PP, x=self.XX, y=self.YY, params=self.params,
                                            method='least_squares', iter_cb=print_status, fit_kws={'verbose': 1,
                                                                                                   'gtol': 1e-8,

--- a/BField_LSQ_package/mu2e/hallprober.py
+++ b/BField_LSQ_package/mu2e/hallprober.py
@@ -499,7 +499,8 @@ def make_fit_plots(df, cfg_data, cfg_geom, cfg_plot, name, aspect='square', para
             if plot_type == 'mpl_nonuni':
                 mu2e_plot3d_nonuniform_test(df, ABC[0], ABC[1], ABC[2], conditions=conditions_str,
                                             df_fit=True, mode=plot_type, save_dir=save_dir,
-                                            do2pi=cfg_geom.do2pi, units='m', df_fine=df_fine)
+                                            do2pi=cfg_geom.do2pi, units='m', df_fine=df_fine,
+                                            show_plot=False)
             else:
                 save_name = mu2e_plot3d(df, ABC[0], ABC[1], ABC[2], conditions=conditions_str,
                                         df_fit=True, mode=plot_type, save_dir=save_dir,
@@ -631,6 +632,10 @@ def field_map_analysis(name, cfg_data, cfg_geom, cfg_params, cfg_pickle, cfg_plo
             pkl.dump(ff.input_data, open(cfg_data.path.split('.')[0]+f'_{cfg_pickle.load_name.split("_")[-1]}.Mu2E.Fit.p', "wb"), pkl.HIGHEST_PROTOCOL)
         else:
             pkl.dump(ff.input_data, open(cfg_data.path.split('.')[0]+'.Mu2E.Fit.p', "wb"), pkl.HIGHEST_PROTOCOL)
+    # FIXME! Are there any other cases to add? e.g. "cyl" with recreate will not make a file currently.
+    # else:
+    #     save_name = cfg_data.path.split('.')[0]+'.Mu2e.Fit_rec.p'
+    #     pkl.dump(ff.input_data, open(save_name, 'wb'), pkl.HIGHEST_PROTOCOL)
 
     # eval on full set of points if some were left out
     if not hall_measure_data_eval is None:

--- a/BField_LSQ_package/mu2e/hallprober.py
+++ b/BField_LSQ_package/mu2e/hallprober.py
@@ -85,6 +85,9 @@ from mu2e.dataframeprod import DataFrameMaker
 from mu2e.fieldfitter_redux2 import FieldFitter
 from mu2e.mu2eplots import mu2e_plot3d, mu2e_plot3d_nonuniform_test, mu2e_plot3d_nonuniform_cyl
 from mu2e.syst_unc import laserunc, metunc, apply_field_unc
+# FIXME! It's messy and confusing that we use the same variable names to refer to
+# the named tuple instances in this code as we use to define the namedtuples in cfg_defs.
+from mu2e.cfg_defs import cfg_pickle as cfg_pickle_maker
 from mu2e import mu2e_ext_path
 import imp
 from six.moves import range
@@ -565,6 +568,13 @@ def field_map_analysis(name, cfg_data, cfg_geom, cfg_params, cfg_pickle, cfg_plo
     #        hall_measure_data.loc[:,field] += noise_vec
     #    hall_measure_data.eval('Bx = Br*cos(Phi)-Bphi*sin(Phi)', inplace=True)
     #    hall_measure_data.eval('By = Bphi*cos(Phi)+Br*sin(Phi)', inplace=True)
+
+    # make a copy of hall measure data
+    if "fit_point" in hall_measure_data.columns:
+        hall_measure_data_eval = hall_measure_data.copy()
+        hall_measure_data = hall_measure_data.query("fit_point").copy().reset_index()
+    else:
+        hall_measure_data_eval = None
         
     print(hall_measure_data.head())
     print(hall_measure_data.columns)
@@ -622,19 +632,72 @@ def field_map_analysis(name, cfg_data, cfg_geom, cfg_params, cfg_pickle, cfg_plo
         else:
             pkl.dump(ff.input_data, open(cfg_data.path.split('.')[0]+'.Mu2E.Fit.p', "wb"), pkl.HIGHEST_PROTOCOL)
 
+    # eval on full set of points if some were left out
+    if not hall_measure_data_eval is None:
+        print('Evaluating on all point in measured df (not filtered by "fit_point" bool).')
+        ff_eval = FieldFitter(hall_measure_data_eval, None)
+        cfg_pickle_eval = cfg_pickle_maker(use_pickle=False, save_pickle=False,
+                                           load_name='eval',
+                                           save_name='eval', recreate=False)
+        ff_eval.prep_fit_func(cfg_params, cfg_pickle_eval)
+        model_eval = ff_eval.model()
+        fit_eval = model_eval.eval(r=hall_measure_data_eval.R.values, z=hall_measure_data_eval.Z.values,
+                                   phi=hall_measure_data_eval.Phi.values, x=hall_measure_data_eval.X.values,
+                                   y=hall_measure_data_eval.Y.values, params=ff.params)
+        hall_measure_data_eval.loc[:,'Br_fit']   = fit_eval[0:len(fit_eval)//3]
+        hall_measure_data_eval.loc[:,'Bz_fit']   = fit_eval[len(fit_eval)//3:2*len(fit_eval)//3]
+        hall_measure_data_eval.loc[:,'Bphi_fit'] = fit_eval[2*len(fit_eval)//3:]
+        plot_data = hall_measure_data_eval
+
+        # If fit uncertainties were saved in main fit, compute also for fine grid
+        if saveunc:
+            fit_unc = custom_eval_unc(model=model_eval, r=hall_measure_data_eval.R.values, z=hall_measure_data_eval.Z.values,
+                                      phi=hall_measure_data_eval.Phi.values, x=hall_measure_data_eval.X.values,
+                                      y=hall_measure_data.Y.values, params=ff.params)
+            hall_measure_data_eval.loc[:,'Br_unc']   = fit_unc[0:len(fit_unc)//3]
+            hall_measure_data_eval.loc[:,'Bz_unc']   = fit_unc[len(fit_unc)//3:2*len(fit_unc)//3]
+            hall_measure_data_eval.loc[:,'Bphi_unc'] = fit_unc[2*len(fit_unc)//3:]
+            if cfg_params.noise is not None:
+                # #NOMINAL CASE:
+                # pkl.dump(ff.input_data, open(cfg_data.path.split('.')[0]+'.Mu2E.Fit.p', "wb"), pkl.HIGHEST_PROTOCOL)
+                save_file = cfg_data.path.split('.')[0] + f'_noise{cfg_params.noise}_eval' + '.Mu2E.Fit.p'
+                pkl.dump(hall_measure_data_eval, open(save_file, "wb"), pkl.HIGHEST_PROTOCOL)
+            else:
+                save_file = cfg_data.path.split('.')[0] + f'_eval' + '.Mu2E.Fit.p'
+                pkl.dump(hall_measure_data_eval, open(save_file, "wb"), pkl.HIGHEST_PROTOCOL)
+
+        # 'Fit' to nominal with syst. params
+        elif cfg_pickle.load_name.endswith('Unc') and cfg_pickle.recreate:
+            save_file = cfg_data.path.split('.')[0]+f"_{cfg_pickle.load_name.split('_')[-1]}_eval.Mu2E.Fit.p"
+            pkl.dump(hall_measure_data_eval, open(save_file, "wb"), pkl.HIGHEST_PROTOCOL)
+
+        # Fitting to variant DSCylFMSAll map, comparing against nominal DSCylFine (ex. fitting to PINN-subtracted systematic)
+        # TODO make this more inclusive
+        elif 'Unc' in cfg_data.path:
+            unc = [p for p in cfg_data.path.split('_') if 'Unc' in p][0]
+            save_name = cfg_data.path.split('.')[0]+f"_{unc}_eval.Mu2E.Fit.p"
+            pkl.dump(hall_measure_data_eval, open(save_name, "wb"), pkl.HIGHEST_PROTOCOL)
+
+        # In all other cases, name of DSCylFine fit should match DSCylFine map?
+        else:
+            save_name = cfg_data.paht.split('.')[0]+f"_eval.Mu2E.Fit.p"
+            pkl.dump(hall_measure_data_eval, open(save_name, "wb"), pkl.HIGHEST_PROTOCOL)
+
+    else:
+        plot_data = ff.input_data.copy()
+        plot_data.loc[:, 'fit_point'] = True
+
     if cfg_plot.df_fine is not None:
+        print('Evaluating on df_fine.')
         df_fine = DataFrameMaker(cfg_plot.df_fine, input_type='pkl').data_frame
         df_fine = df_fine.sort_values(['Z', 'R', 'Phi'])
         print("df_fine")
         print(df_fine)
         # Need to manually define functional form
         ff_fine = FieldFitter(df_fine, None)
-        from collections import namedtuple
-        pickle_temp = namedtuple('pickle_temp', 'use_pickle save_pickle load_name save_name recreate')
-
-        cfg_pickle_fine = pickle_temp(use_pickle=False, save_pickle=False,
-                                      load_name='fine',
-                                      save_name='fine', recreate=False)
+        cfg_pickle_fine = cfg_pickle_maker(use_pickle=False, save_pickle=False,
+                                           load_name='fine',
+                                           save_name='fine', recreate=False)
         ff_fine.prep_fit_func(cfg_params, cfg_pickle_fine)
         model_fine = ff_fine.model()
         fit_fine = model_fine.eval(r=df_fine.R.values, z=df_fine.Z.values, phi=df_fine.Phi.values, x=df_fine.X.values, y=df_fine.Y.values, params=ff.params)
@@ -670,7 +733,7 @@ def field_map_analysis(name, cfg_data, cfg_geom, cfg_params, cfg_pickle, cfg_plo
     else:
         df_fine = None
     if cfg_plot.plot_type != 'none':
-        make_fit_plots(ff.input_data, cfg_data, cfg_geom, cfg_plot, name, aspect=aspect, parallel=parallel_plots, df_fine=df_fine)
+        make_fit_plots(plot_data, cfg_data, cfg_geom, cfg_plot, name, aspect=aspect, parallel=parallel_plots, df_fine=df_fine)
         
     return hall_measure_data, ff
 

--- a/BField_LSQ_package/mu2e/mu2eplots.py
+++ b/BField_LSQ_package/mu2e/mu2eplots.py
@@ -526,6 +526,10 @@ def mu2e_plot3d_nonuniform_test(df, x, y, z, conditions=None, mode='mpl', info=N
     Y = df[y]
     Z = df[z]
 
+    # mask for colors
+    mask_fit = df.fit_point
+    mask_not_fit = ~mask_fit
+
     zmax_SP = np.max(df[df['HP'].str.contains('SP')].Z)
     zmin_BP = np.min(df[df['HP'].str.contains('BP')].Z)
     
@@ -545,6 +549,8 @@ def mu2e_plot3d_nonuniform_test(df, x, y, z, conditions=None, mode='mpl', info=N
     #Z slices with SP points only
     dfs_SP = []
     df_SP = df[df.Z < zmin_BP-0.025]
+    fp = df_SP.loc[:, 'fit_point'].astype(float)
+    df_SP = df_SP[[c for c in df_SP.columns if c != "fit_point"]]
     for iSP in range(int(df_SP.shape[0]/nSP)):
         df_SP_slice = df_SP[iSP*nSP:(iSP+1)*nSP]
         df_BP = pd.DataFrame(columns=df.columns,index=range(nBP), dtype=float)
@@ -563,10 +569,13 @@ def mu2e_plot3d_nonuniform_test(df, x, y, z, conditions=None, mode='mpl', info=N
     # Z slices with BP points only
     dfs_BP = []
     df_BP = df[df.Z > zmax_SP+0.025]
+    fp = df_BP.loc[:, 'fit_point'].astype(float)
+    df_BP = df_BP[[c for c in df_BP.columns if c != "fit_point"]]
     for iBP in range(int(df_BP.shape[0]/nBP)):
         df_BP_slice = df_BP[iBP*nBP:(iBP+1)*nBP]
         df_SP = pd.DataFrame(columns=df.columns,index=range(nSP), dtype=float)
         df_SP['HP'] = df_SP['HP'].astype(object)
+        df_SP['fit_point'] = df_SP['fit_point'].astype(float)
         df_SP.loc[:,'R'] = r_SP
         df_slice = pd.concat([df_BP_slice,df_SP])
         df_slice.sort_values(by=['R'],inplace=True)
@@ -631,7 +640,10 @@ def mu2e_plot3d_nonuniform_test(df, x, y, z, conditions=None, mode='mpl', info=N
 
         if df_fit:
             ax = fig.add_subplot(1, 2, 1, projection='3d')
-            ax.plot(X, Y, Z, 'ko', markersize=2, zorder=100)
+            # fit
+            ax.plot(X[mask_fit], Y[mask_fit], Z[mask_fit], 'ko', alpha=1.0, markersize=2, zorder=101)
+            # not fit
+            ax.plot(X[mask_not_fit], Y[mask_not_fit], Z[mask_not_fit], 'ro', alpha=0.5, markersize=2, zorder=100)
             ax.plot_wireframe(Xi, Yi, Z_fit, color='green', zorder=99)
         elif ptype.lower() == '3d':
             if not ax:

--- a/BField_LSQ_package/mu2e/mu2eplots.py
+++ b/BField_LSQ_package/mu2e/mu2eplots.py
@@ -686,7 +686,8 @@ def mu2e_plot3d_nonuniform_test(df, x, y, z, conditions=None, mode='mpl', info=N
             ax.view_init(elev=30., azim=30)
         if save_dir and not df_fit:
             plt.savefig(save_dir+'/'+save_name+'.png')
-            plt.clf()
+            if not show_plot:
+                plt.clf()
 
         if df_fit:
             ax2 = fig.add_subplot(1, 2, 2)
@@ -702,7 +703,8 @@ def mu2e_plot3d_nonuniform_test(df, x, y, z, conditions=None, mode='mpl', info=N
             ax.dist = 11 # default 10
             if save_dir:
                 plt.savefig(save_dir+'/'+save_name+'_heat.pdf')
-            plt.clf()
+            if not show_plot:
+                plt.clf()
 
             # TODO turn this on/off with a flag in cfg_plot
             '''
@@ -731,6 +733,7 @@ def mu2e_plot3d_nonuniform_test(df, x, y, z, conditions=None, mode='mpl', info=N
                 plt.savefig(save_dir+'/'+save_name+'_unc.pdf')
             plt.clf()
             '''
+    return fig, ax
 
 def mu2e_plot3d_nonuniform_cyl(df, x, y, z, conditions=None, mode='mpl', cut_color=5, info=None, save_dir=None, save_name=None,
                                df_fit=None, ptype='3d', aspect='square', cmin=None, cmax=None, fig=None, ax=None,

--- a/BField_LSQ_package/mu2e/mu2eplots.py
+++ b/BField_LSQ_package/mu2e/mu2eplots.py
@@ -623,12 +623,11 @@ def mu2e_plot3d_nonuniform_test(df, x, y, z, conditions=None, mode='mpl', info=N
     if 'mpl' in mode:
         if not ax:
             if ptype.lower() == '3d' and not df_fit:
-                fig = plt.figure()
+                fig = plt.figure(constrained_layout='constrained')
             elif ptype.lower() == 'heat':
-                fig = plt.figure()
+                fig = plt.figure(constrained_layout='constrained')
             else:
-                fig = plt.figure(figsize=plt.figaspect(0.4), constrained_layout=True)
-                fig.set_constrained_layout_pads(hspace=0., wspace=0.15)
+                fig = plt.figure(figsize=plt.figaspect(0.4), constrained_layout='constrained')
 
         if df_fit:
             ax = fig.add_subplot(1, 2, 1, projection='3d')

--- a/BField_LSQ_package/mu2e/tools/fit_funcs_redux.py
+++ b/BField_LSQ_package/mu2e/tools/fit_funcs_redux.py
@@ -3826,3 +3826,257 @@ def brzphi_3d_producer_giant_function_v1005(z, r, phi,
 
         return np.concatenate([model_r, model_z, model_phi]).ravel()
     return brzphi_3d_fast
+
+# adding z0
+def brzphi_3d_producer_giant_function_v1006(z, r, phi,
+                                            pitch1, ms_h1, ns_h1,
+                                            pitch2, ms_h2, ns_h2,
+                                            length1, ms_c1, ns_c1,
+                                            length2, ms_c2, ns_c2,
+                                            bz_input=None, br_input=None, bphi_input=None):
+    '''
+    Factory function that readies a potential fit function for a 3D magnetic field.
+    This function includes:
+        2 copies of the cylindrical expansion.
+        2 copies of the helical expansion (with both left and right handed sol'n).
+        The BS functions.
+        The trivial cartesian functions.
+
+    The reasoning behind doubling up on series expansions is to hit both the high frequency
+    (helically induced) and low frequency (finite-length induced) components of a mag field without
+    forcing a series expansion to collect terms forever.
+
+    Ms and Ns are redefined: Ms now always correspond to z-related frequencies, and Ns correspond to
+    phi-related frequencies.  Coefficients are now A_m_n instead of A_n_m (which was a dyslexic
+    oversight to begin with).
+
+    Ms always have a +1, Ns always start at 0 (The m=0 term is always 0)
+
+    Left and right handed helical solutions are coupled for ease of use (expanded to same number of
+    terms).  This is not a requirement and could be decoupled if you add more starting parameters.
+    '''
+
+    # Set up helical bessels
+    pitch1b = pitch1/(2*np.pi)
+    pitch2b = pitch2/(2*np.pi)
+
+    iv_h1 = np.zeros((ms_h1, ns_h1, len(r)))
+    ivp_h1 = np.zeros((ms_h1, ns_h1, len(r)))
+    hms1 = np.zeros(ms_h1)
+
+    iv_h2 = np.zeros((ms_h2, ns_h2, len(r)))
+    ivp_h2 = np.zeros((ms_h2, ns_h2, len(r)))
+    hms2 = np.zeros(ms_h2)
+
+    for m_h1 in range(ms_h1):
+        hms1[m_h1] = (m_h1+1)/pitch1b
+        for n_h1 in range(ns_h1):
+                iv_h1[m_h1][n_h1] = special.iv(n_h1, hms1[m_h1]*r)
+                ivp_h1[m_h1][n_h1] = special.ivp(n_h1, hms1[m_h1]*r)
+
+    for m_h2 in range(ms_h2):
+        hms2[m_h2] = (m_h2+1)/pitch2b
+        for n_h2 in range(ns_h2):
+                iv_h2[m_h2][n_h2] = special.iv(n_h2, hms2[m_h2]*r)
+                ivp_h2[m_h2][n_h2] = special.ivp(n_h2, hms2[m_h2]*r)
+
+    # Set up cylindrical bessels
+    cms1 = np.zeros(ms_c1)
+    iv_c1 = np.zeros((ms_c1, ns_c1, len(r)))
+    ivp_c1 = np.zeros((ms_c1, ns_c1, len(r)))
+
+    for m in range(ms_c1):
+        cms1[m] = (2*(m+1)*np.pi/length1)
+        for n in range(ns_c1):
+            iv_c1[m][n] = special.iv(n, cms1[m]*r)
+            ivp_c1[m][n] = special.ivp(n, cms1[m]*r)
+
+    jv_c2 = np.zeros((ms_c2, ns_c2, len(r)))
+    jvp_c2 = np.zeros((ms_c2, ns_c2, len(r)))
+
+    b_zeros = []
+    for n_c2 in range(ns_c2):
+        b_zeros.append(special.jn_zeros(n_c2, ms_c2))
+    cms2 = np.asarray([b/length2 for b in b_zeros])
+    for m_c2 in range(ms_c2):
+        for n_c2 in range(ns_c2):
+            jv_c2[m_c2][n_c2] = special.jv(n_c2, cms2[n_c2][m_c2]*r)
+            jvp_c2[m_c2][n_c2] = special.jvp(n_c2, cms2[n_c2][m_c2]*r)
+
+    # PAPER CALLS THIS LEFT HANDED
+    @njit(parallel=True)
+    def calc_b_fields_helR(z, phi, r, hms, n, A, B, iv, ivp, model_r, model_z, model_phi):
+        for i in prange(z.shape[0]):
+            model_r[i] += hms * \
+                (ivp[i]*(A*np.cos(hms*z[i]+n*phi[i]) +
+                         B*np.sin(hms*z[i]+n*phi[i])))
+
+            model_z[i] += hms * \
+                (iv[i]*(-A*np.sin(hms*z[i]+n*phi[i]) +
+                        B*np.cos(hms*z[i]+n*phi[i])))
+            if abs(r[i]) >= 1e-5:
+                model_phi[i] += (1.0/r[i]) * \
+                    -(n*iv[i]*(A*np.sin(hms*z[i]+n*phi[i]) -
+                               B*np.cos(hms*z[i]+n*phi[i])))
+
+    # PAPER CALLS THIS RIGHT HANDED
+    @njit(parallel=True)
+    def calc_b_fields_helL(z, phi, r, hms, n, C, D, iv, ivp, model_r, model_z, model_phi):
+        for i in prange(z.shape[0]):
+            model_r[i] += hms * \
+                (ivp[i]*(C*np.cos(-hms*z[i]+n*phi[i]) +
+                         D*np.sin(-hms*z[i]+n*phi[i])))
+
+            model_z[i] += -hms * \
+                (iv[i]*(-C*np.sin(-hms*z[i]+n*phi[i]) +
+                        D*np.cos(-hms*z[i]+n*phi[i])))
+
+            if abs(r[i]) >= 1e-5:
+                model_phi[i] += (1.0/r[i]) * \
+                    -(n*iv[i]*(C*np.sin(-hms*z[i]+n*phi[i]) -
+                               D*np.cos(-hms*z[i]+n*phi[i])))
+
+    @njit(parallel=True)
+    def calc_b_fields_cyl(z, phi, r, cms, n, A, B, D, iv, ivp, model_r, model_z, model_phi):
+        for i in prange(z.shape[0]):
+            if n > 0:
+                model_r[i] += np.sin(n*phi[i]+D)*ivp[i]*cms*( A*np.cos(cms*z[i]) + B*np.sin(cms*z[i]))
+                model_z[i] += np.sin(n*phi[i]+D)*iv[i] *cms*(-A*np.sin(cms*z[i]) + B*np.cos(cms*z[i]))
+                if abs(r[i]) >= 1e-5:
+                    model_phi[i] += n*np.cos(n*phi[i]+D)*(1/r[i])*iv[i]*(A*np.cos(cms*z[i]) + B*np.sin(cms*z[i]))
+                elif n == 1:
+                    model_phi[i] += n*np.cos(n*phi[i]+D)*cms/2*(A*np.cos(cms*z[i]) + B*np.sin(cms*z[i]))
+            else:
+                model_r[i] += ivp[i]*cms*(A*np.cos(cms*z[i]) + B*np.sin(cms*z[i]))
+                model_z[i] += iv[i]*cms*(-A*np.sin(cms*z[i]) + B*np.cos(cms*z[i]))
+
+    @njit(parallel=True)
+    def calc_b_fields_cyl2(z, phi, r, cms, n, A, B, D, jv, jvp, model_r, model_z, model_phi):
+        for i in prange(z.shape[0]):
+            model_r[i] += (D*np.sin(n*phi[i]) + (1-D)*np.cos(n*phi[i])) * \
+                jvp[i]*cms*(A*np.sinh(cms*z[i]) + B*np.cosh(cms*z[i]))
+
+            model_z[i] += (D*np.sin(n*phi[i]) + (1-D)*np.cos(n*phi[i])) * \
+                jv[i]*cms*(A*np.cosh(cms*z[i]) + B*np.sinh(cms*z[i]))
+            if abs(r[i]) >= 1e-5:
+                model_phi[i] += n*(D*np.cos(n*phi[i]) - (1-D)*np.sin(n*phi[i])) * \
+                    (1/r[i])*jv[i]*(A*np.sinh(cms*z[i]) + B*np.cosh(cms*z[i]))
+
+    @njit(parallel=True)
+    def calc_b_fields_cart(x, y, z, phi, vx, vy, vz, x0, y0, z0,
+                           model_r, model_phi, model_z):
+        for i in prange(z.shape[0]):
+            v = np.array([vx, vy, vz])
+            r = np.array([x[i]-x0, y[i]-y0, z[i]-z0])
+            rsq = np.linalg.norm(r)**2
+            res = np.array([v[1]*r[2]-v[2]*r[1], v[2]*r[0]-v[0]*r[2],
+                            v[0]*r[1]-v[1]*r[0]])/rsq
+            model_xt, model_yt, model_zt = res
+
+            model_z[i] += model_zt
+            model_r[i] += model_xt*np.cos(phi[i]) + model_yt*np.sin(phi[i])
+            model_phi[i] += -model_xt*np.sin(phi[i]) + model_yt*np.cos(phi[i])
+
+    @njit(parallel=True)
+    def calc_b_fields_cart2(x, y, z, phi, k1, k2, k3, k4, k5, k6, k7, k8, k9, k10,
+                            model_r, model_phi, model_z):
+        for i in prange(z.shape[0]):
+            # Kampa
+            model_x = k1 + k4*y[i] + k5*z[i] + k7*y[i]*z[i]
+            model_y = k2 + k4*x[i] + k6*z[i] + k7*x[i]*z[i]
+
+            model_z[i] += k3 + k5*x[i] + k6*y[i] + k7*x[i]*y[i]
+
+            model_r[i] += model_x*np.cos(phi[i]) + model_y*np.sin(phi[i])
+            model_phi[i] += -model_x*np.sin(phi[i]) + model_y*np.cos(phi[i])
+
+    def brzphi_3d_fast(z, r, phi, x, y, **AB_params):
+        """ 3D model for Bz Br and Bphi vs Z and R. Can take any number of AnBn terms."""
+
+        model_r = np.zeros(z.shape, dtype=np.float64)
+        model_z = np.zeros(z.shape, dtype=np.float64)
+        model_phi = np.zeros(z.shape, dtype=np.float64)
+
+        z0 = AB_params['z0']
+        z_ = z - z0
+
+        # PAPER CALLS THIS RIGHT HANDED
+        for m in range(ms_h1):
+            for n in range(ns_h1):
+                A = AB_params[f'Ah1_{m}_{n}']
+                B = AB_params[f'Bh1_{m}_{n}']
+                C = AB_params[f'Ch1_{m}_{n}']
+                D = AB_params[f'Dh1_{m}_{n}']
+                calc_b_fields_helR(z_, phi, r, hms1[m], n, A, B, iv_h1[m][n], ivp_h1[m][n],
+                                   model_r, model_z, model_phi)
+
+                # CHECK! I don't think this goes here...
+                # It might, but this is stil a weird way to initialize.
+                calc_b_fields_helL(z_, phi, r, hms1[m], n, C, D, iv_h1[m][n], ivp_h1[m][n],
+                                   model_r, model_z, model_phi)
+
+        # PAPER CALLS THIS LEFT HANDED
+        for m in range(ms_h2):
+            for n in range(ns_h2):
+                A = AB_params[f'Ah2_{m}_{n}']
+                B = AB_params[f'Bh2_{m}_{n}']
+                C = AB_params[f'Ch2_{m}_{n}']
+                D = AB_params[f'Dh2_{m}_{n}']
+                # CHECK! I don't think this goes here...
+                # It might, but this is stil a weird way to initialize.
+                calc_b_fields_helR(z_, phi, r, hms2[m], n, A, B, iv_h2[m][n], ivp_h2[m][n],
+                                   model_r, model_z, model_phi)
+                calc_b_fields_helL(z_, phi, r, hms2[m], n, C, D, iv_h2[m][n], ivp_h2[m][n],
+                                   model_r, model_z, model_phi)
+
+        for m in range(ms_c1):
+            for n in range(ns_c1):
+                A = AB_params[f'Ac1_{m}_{n}']
+                B = AB_params[f'Bc1_{m}_{n}']
+                D = AB_params[f'Dc1_{n}']
+                calc_b_fields_cyl(z_, phi, r, cms1[m], n, A, B, D, iv_c1[m][n], ivp_c1[m][n],
+                                  model_r, model_z, model_phi)
+
+        for m in range(ms_c2):
+            for n in range(ns_c2):
+                A = AB_params[f'Ac2_{m}_{n}']
+                B = AB_params[f'Bc2_{m}_{n}']
+                D = AB_params[f'Dc2_{n}']
+                calc_b_fields_cyl2(z_, phi, r, cms2[n][m], n, A, B, D, jv_c2[m][n], jvp_c2[m][n],
+                                   model_r, model_z, model_phi)
+
+        n_bs = len([bs for bs in AB_params.keys() if 'vx' in bs])
+        for i in range(1, n_bs+1):
+            vx = AB_params[f'vx{i}']
+            vy = AB_params[f'vy{i}']
+            vz = AB_params[f'vz{i}']
+            x0 = AB_params[f'x{i}']
+            y0 = AB_params[f'y{i}']
+            z0 = AB_params[f'z{i}']
+            calc_b_fields_cart(x, y, z_, phi, vx, vy, vz, x0, y0, z0,
+                               model_r, model_phi, model_z)
+
+        k1 = AB_params['k1']
+        k2 = AB_params['k2']
+        k3 = AB_params['k3']
+        k4 = AB_params['k4']
+        k5 = AB_params['k5']
+        k6 = AB_params['k6']
+        k7 = AB_params['k7']
+        k8 = AB_params['k8']
+        k9 = AB_params['k9']
+        k10 = AB_params['k10']
+        calc_b_fields_cart2(x, y, z_, phi, k1, k2, k3, k4, k5, k6, k7, k8, k9, k10,
+                            model_r, model_phi, model_z)
+
+        # any calculated fields to add on?
+        # e.g. bus bars
+        if bz_input is not None:
+            model_z += bz_input
+        if br_input is not None:
+            model_r += br_input
+        if bphi_input is not None:
+            model_phi += bphi_input
+
+        return np.concatenate([model_r, model_z, model_phi]).ravel()
+    return brzphi_3d_fast


### PR DESCRIPTION
General fixes:
- scale_covar is now set to False, to avoid parameter covariance and uncertainties being scaled by sqrt(reduced chi2).
- Logic added to incorporate a boolean column "fit_point" in the input dataframe to leave some points out of the fit, e.g. if fitting using only the external points from the mapper.
- cfg_pickle added as an import for df_fine and df_eval calculations.
- Printout checkpoints
- Fixed RMS / noise to apply to weights in all calls to lm.Model.fit.
- Bootstr

Model updates (v1006):
- Functionality to limit A/B parameters and k parameters.
- Bug in bootstrapping / load_params for cases with ms_asym_max >= 0 fixed.

A few plotting updates:
- Axis label cutoff fixed.
- Different color used for points where "fit_point" is False (see above). This requires an additional evaluation on the original dataframe (saved in hallprober.field_map_analysis as hall_measure_data_eval).
- Updated current plotting function (mu2eplots.mu2e_plot3d_nonuniform_test) to clf plots only when show_plots=False. Also added fig and ax return.